### PR TITLE
Ignore whole .idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/workspace.xml
-/.idea/libraries
+/.idea
 .DS_Store
 /build
 /captures

--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ A quick settings tile to quickly set the animator duration scale. Two tiles are 
 1. A toggle which switches between 5x & 1x duration scales.
 2. A selector which offers the full choice of scales.
 
-Note that changing the animator duration requires you to *manually grant permission* to allow the app to alter this setting. This can be done via `adb` using the following command:
+Note that this app requires you to **manually grant permission** to allow the app to alter the animator duration setting. To do this, issue the following `adb` command:
 
 `adb shell pm grant uk.co.nickbutcher.animatordurationtile android.permission.WRITE_SECURE_SETTINGS`
 
 
 <img src="screenshots/duration_scale_toggle_demo.gif" align="middle">
+
+
+This is not an official Google product.
 
 
 ### License


### PR DESCRIPTION
Upon importing a freshly cloned repo Android Studio creates a bunch of config files in .idea directory. For me there was one because I clicked on the suggestion to add a VCS root. Another because I fixed the run configuration (by default it tries to launch an activity, but there is none here, so the default run config was not functional). There's a bunch more of them that just spawned automatically without any action on my part.

I am assuming there is no intention to sync this configuration between clones, seeing as it isn't provided in the repository. I agree with this choice and with this change suggest to simply ignore the whole .idea directory and let each Android Studio instance generate it's own config files.
